### PR TITLE
Sign in raise a error when failing

### DIFF
--- a/lib/simple_auth/session.rb
+++ b/lib/simple_auth/session.rb
@@ -127,7 +127,7 @@ module SimpleAuth
         true
       else
         errors.add_to_base I18n.translate("simple_auth.sessions.invalid_credentials")
-        self.class.destroy!
+        #self.class.destroy!
         false
       end
     end
@@ -137,7 +137,7 @@ module SimpleAuth
     end
 
     def save
-      self.class.destroy!
+      #self.class.destroy! if self.class
 
       controller.session[self.class.session_key] = record.id if valid?
       controller.session[self.class.session_key] != nil
@@ -155,7 +155,7 @@ module SimpleAuth
       @record = nil
       @credential = nil
       @password = nil
-      self.class.destroy!
+      #self.class.destroy! if self.class
     end
   end
 end


### PR DESCRIPTION
Hey Fernando, Im getting a error when my login fail with this code: 

  @user_session = SimpleAuth::Session.new(params[:simple_auth_session])
       if @user_session.save
        else
           render :text => "#{return_to}"
       end

I think that save dont need raise a exception if the login fail, and just return a false, right? 
Well, I hope I dont doing anything wrong

thank you
