### PR TITLE
Removed Deprecation warning on Rails 4.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     simple_auth (1.4.5)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.12)
       actionpack (= 3.2.12)

--- a/lib/simple_auth/orm/active_record.rb
+++ b/lib/simple_auth/orm/active_record.rb
@@ -52,21 +52,21 @@ module SimpleAuth
         #   User.find_by_credential "john" # using username
         #
         def find_by_credential(credential)
-          # Build a hash that will be passed to the finder
-          options = {:conditions => [[], {}]}
+          # Build a array that will be passed to the finder
+          options = [[], {}]
 
           # Iterate each attribute that should be used as credential
           # and set it to the finder conditions hash
           SimpleAuth::Config.credentials.each do |attr_name|
-            options[:conditions][0] << "#{attr_name} = :#{attr_name}"
-            options[:conditions][1][attr_name] = credential
+            options[0] << "#{attr_name} = :#{attr_name}"
+            options[1][attr_name] = credential
           end
 
           # Join the attributes in OR query
-          options[:conditions][0] = options[:conditions][0].join(" OR ")
+          options[0] = options[0].join(" OR ")
 
           # Find the record using the conditions we built
-          SimpleAuth::Config.model_class.first(options)
+          SimpleAuth::Config.model_class.where(options).first
         end
 
         # Find user by its credential. If no user is found, raise


### PR DESCRIPTION
When users are searched, the following message is displayed on Rails 4:
"DEPRECATION WARNING: Relation#first with finder options is deprecated. Please build a scope and then call #first on it instead."
